### PR TITLE
Add Connect styling to Quickstart buttons

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,6 +1,38 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <style>
+      .connectButton {
+        background: rgb(0, 64, 55);
+        border: 1px solid rgb(0, 64, 55);
+        color: rgb(255, 255, 255);
+        border-radius: 8px;
+        font-family: "DM Sans Bold", sans-serif;
+        cursor: pointer;
+        box-sizing: border-box;
+        display: inline-flex;
+        -webkit-box-align: center;
+        align-items: center;
+        -webkit-box-pack: center;
+        justify-content: center;
+        font-size: 1rem;
+        line-height: 1;
+        padding: 15px 16px;
+        text-align: center;
+        text-decoration: none;
+        transition: all 0.1s ease 0s;
+        white-space: normal;
+        -webkit-font-smoothing: antialiased;
+        margin: 0px;
+      }
+      .connectButton:disabled {
+        cursor: not-allowed;
+        opacity: 0.5;
+      }
+      .connectButton:hover {
+        background: rgb(0, 58, 50);
+      }
+    </style>
     <meta charset="utf-8" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" sizes="any">

--- a/src/connect-widget.jsx
+++ b/src/connect-widget.jsx
@@ -35,7 +35,7 @@ const ConnectWidget = () => {
 
   const renderConnectBtn = (
       // When the button is clicked, we call Connect's open method in order to display the modal
-      <button type="button" disabled={loading || !config} onClick={() => open(config)}>
+      <button type="button" className="connectButton" disabled={loading || !config} onClick={() => open(config)}>
         Launch Connect
       </button>
   );


### PR DESCRIPTION
Mirrored the styling of the Connect button class for the Quickstart buttons.
This takes the experience from this:
<img width="90" alt="image" src="https://user-images.githubusercontent.com/4309226/166065597-edbab811-fc3c-4cab-b342-9d8415b7cfc1.png">


to this:
<img width="208" alt="image" src="https://user-images.githubusercontent.com/4309226/166065394-2eae910e-7942-4f49-95bf-f7b3a0bf65a5.png">

<img width="799" alt="image" src="https://user-images.githubusercontent.com/4309226/166065794-f1f64407-1c27-4d6f-b212-651056c0c195.png">


p.s. I know this is a little hacky to have the styling right in the HTML as opposed to a CSS stylesheet or something fancier but... Brandon said I could? :)