### PR TITLE
Use self-hosted runners for gitleaks workflow

### DIFF
--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   scan:
     name: gitleaks
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, runner-main]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Move gitleaks workflow to use self-hosted runners.