### PR TITLE
Add timeout to Gitleaks workflow

### DIFF
--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -11,6 +11,7 @@ jobs:
   scan:
     name: gitleaks
     runs-on: ubuntu-latest
+    timeout-minutes: 3
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Adding a timeout to the Gitleaks workflow to prevent potential excessive minutes consumption.